### PR TITLE
エディタメニューから iPhone X Tester をセットできるようにする

### DIFF
--- a/Assets/Images/Sprites/iPhoneX/FrameLandscape.png.meta
+++ b/Assets/Images/Sprites/iPhoneX/FrameLandscape.png.meta
@@ -64,21 +64,21 @@ TextureImporter:
     allowsAlphaSplitting: 0
     overridden: 0
   - buildTarget: Standalone
-    maxTextureSize: 2048
-    textureFormat: -1
+    maxTextureSize: 4096
+    textureFormat: 4
     textureCompression: 1
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 0
+    overridden: 1
   - buildTarget: iPhone
-    maxTextureSize: 2048
-    textureFormat: -1
+    maxTextureSize: 4096
+    textureFormat: 4
     textureCompression: 1
     compressionQuality: 50
     crunchedCompression: 0
     allowsAlphaSplitting: 0
-    overridden: 0
+    overridden: 1
   - buildTarget: tvOS
     maxTextureSize: 2048
     textureFormat: -1

--- a/Assets/Scenes/iPhoneX_Tester.unity
+++ b/Assets/Scenes/iPhoneX_Tester.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.3731316, g: 0.38074896, b: 0.3587254, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311918, g: 0.38073993, b: 0.358727, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -110,6 +110,48 @@ NavMeshSettings:
     tileSize: 256
     accuratePlacement: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &180593080
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 180593082}
+  - component: {fileID: 180593081}
+  m_Layer: 0
+  m_Name: Controller
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &180593081
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 180593080}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9718ff61a90494555a73acf10b7b332c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &180593082
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 180593080}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1982522058}
+  - {fileID: 457210205}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &457210202
 GameObject:
   m_ObjectHideFlags: 0
@@ -141,7 +183,7 @@ MonoBehaviour:
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 2768, y: 1278}
+  m_ReferenceResolution: {x: 2436, y: 1125}
   m_ScreenMatchMode: 0
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3
@@ -179,7 +221,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1201154956}
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 180593082}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -219,8 +261,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 600, y: 658}
+  m_AnchoredPosition: {x: 0.000015258789, y: 0}
+  m_SizeDelta: {x: 528.169, y: 579.22534}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1201154957
 MonoBehaviour:
@@ -313,10 +355,10 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1982522053}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 180593082}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 50aea8741a47f46c080fb6a798b171fb
+folderAsset: yes
+timeCreated: 1510239793
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/iPhoneXTester.meta
+++ b/Assets/Scripts/iPhoneXTester.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 28148dc1673604f61a4aac0b3c01ce12
+folderAsset: yes
+timeCreated: 1510243914
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/iPhoneXTester/Controller.cs
+++ b/Assets/Scripts/iPhoneXTester/Controller.cs
@@ -1,0 +1,21 @@
+﻿using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace iPhoneXTester {
+
+    public class Controller : MonoBehaviour {
+
+        private const string SCENE_NAME = "iPhoneX_Tester";
+
+        private void Awake() {
+            this.gameObject.name = SCENE_NAME;
+            DontDestroyOnLoad(this.gameObject);
+        }
+
+        private void Start() {
+            SceneManager.UnloadSceneAsync(SCENE_NAME);
+        }
+
+    }
+
+}

--- a/Assets/Scripts/iPhoneXTester/Controller.cs.meta
+++ b/Assets/Scripts/iPhoneXTester/Controller.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9718ff61a90494555a73acf10b7b332c
+timeCreated: 1510243936
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/iPhoneXTester/Editor.meta
+++ b/Assets/Scripts/iPhoneXTester/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 7d2fa9443a80948ef9f1a387f5831988
+folderAsset: yes
+timeCreated: 1510239798
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/iPhoneXTester/Editor/Launcher.cs
+++ b/Assets/Scripts/iPhoneXTester/Editor/Launcher.cs
@@ -1,0 +1,28 @@
+﻿using iPhoneXTester;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+namespace iPhoneTester.Editor {
+
+    public static class Launcher {
+
+        [MenuItem("Assets/Install iPhone X Tester")]
+        public static void Install() {
+            if (Application.isPlaying) {
+                Debug.LogError("Scene could not install at runtime.");
+                return;
+            }
+            if (Object.FindObjectOfType<Controller>() != default(Controller)) {
+                Debug.LogWarning("iPhoneX Tester already installed.");
+                return;
+            }
+            string[] assets = AssetDatabase.FindAssets("t:Scene iPhoneX_Tester");
+            if (assets.Length > 0) {
+                EditorSceneManager.OpenScene(AssetDatabase.GUIDToAssetPath(assets[0]), OpenSceneMode.Additive);
+            }
+        }
+
+    }
+
+}

--- a/Assets/Scripts/iPhoneXTester/Editor/Launcher.cs.meta
+++ b/Assets/Scripts/iPhoneXTester/Editor/Launcher.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 4b4d9b401d09743a0b08cc1bc27ebb55
+timeCreated: 1510239810
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* ランタイムでの追加は事実上無理っぽい
  * AssetBundle 化して Stream 読み込みする手もあるが、流石に面倒なので妥協する